### PR TITLE
Establish interpreter/compiler semantic parity tests

### DIFF
--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -11,21 +11,21 @@ open IronKernel.Errors
 open IronKernel.Tests.TestHelpers
 
 [<Fact>]
-let ``analyze if define vau and app`` () =
+let ``analyze combinations without privileging operator names`` () =
     match analyze (parseOk "(if #t 1 2)") with
-    | CIf (CLit (Bool true), CLit (Obj _), CLit (Obj _)) -> ()
+    | COperate (CVar "if", [Bool true; Obj _; Obj _]) -> ()
     | other -> failwith (showCore other)
 
     match analyze (parseOk "(define x 1)") with
-    | CDefine (CVar "x", CLit (Obj _)) -> ()
+    | COperate (CVar "define", [Atom "x"; Obj _]) -> ()
     | other -> failwith (showCore other)
 
     match analyze (parseOk "(vau (x) e x)") with
-    | CVau _ -> ()
+    | COperate (CVar "vau", [List [Atom "x"]; Atom "e"; Atom "x"]) -> ()
     | other -> failwith (showCore other)
 
     match analyze (parseOk "(+ 1 2)") with
-    | CApp (CVar "+", [CLit _; CLit _]) -> ()
+    | COperate (CVar "+", [Obj _; Obj _]) -> ()
     | other -> failwith (showCore other)
 
 [<Fact>]

--- a/IronKernel.Tests/ConformanceTests.fs
+++ b/IronKernel.Tests/ConformanceTests.fs
@@ -1,0 +1,63 @@
+module IronKernel.Tests.ConformanceTests
+
+open Xunit
+
+open IronKernel.Ast
+open IronKernel.Tests.TestHelpers
+
+[<Fact>]
+let ``interpreter and compiler agree on core evaluation`` () =
+    assertParitySession
+        [ "42"
+          "(+ 20 22)"
+          "(define x 4)"
+          "(+ x 3)"
+          "(if #t x missing)"
+          "(define raw (vau (x) _ x))"
+          "(raw (+ 1 2))"
+          "((wrap (vau (x) _ x)) (+ 1 2))" ]
+
+[<Fact>]
+let ``operative uses lexical scope and can explicitly evaluate in caller scope`` () =
+    // Revised-1 Report sections 3.2 and 4.10.3.
+    assertParityValueSession
+        [ "(define x 1)"
+          "(define lexical (vau () _ x))"
+          "(define caller-value (vau (form) caller (eval caller form)))"
+          "(define exercise (wrap (vau (x) _ (list (lexical) (caller-value x)))))"
+          "(exercise 2)" ]
+        (List [Obj (1 :> obj); Obj (2 :> obj)])
+
+[<Fact>]
+let ``environment lookup is depth first in parent order`` () =
+    // Adapted from the KPLTS environment-concepts group (Kernel Report 3.2).
+    assertParityValueSession
+        [ "(load \"kernel.scm\")"
+          "(define a (bindings->environment (x 1) (y 2)))"
+          "(define b (bindings->environment (x 3) (z 4)))"
+          "(define c (make-environment a b))"
+          "(list (remote-eval x c) (remote-eval y c) (remote-eval z c))" ]
+        (List [Obj (1 :> obj); Obj (2 :> obj); Obj (4 :> obj)])
+
+[<Fact>]
+let ``wrapped combiner evaluates operands while operative receives syntax`` () =
+    // Revised-1 Report sections 4.10.3 through 4.10.5.
+    assertParityValueSession
+        [ "(define raw (vau operands _ operands))"
+          "(define cooked (wrap raw))"
+          "(list (raw (+ 1 2)) (cooked (+ 1 2)))" ]
+        (List
+            [ List [List [Atom "+"; Obj (1 :> obj); Obj (2 :> obj)]]
+              List [Obj (3 :> obj)] ])
+
+[<Fact>]
+let ``rebinding core names preserves combination semantics`` () =
+    [ [ "(define if (vau xs e xs))"; "(if 1 2 3)" ]
+      [ "(define quote (vau xs e xs))"; "(quote (+ 1 2))" ]
+      [ "(define define (vau xs e xs))"; "(define x missing)" ]
+      [ "(define vau (vau xs e xs))"; "(vau (x) e missing)" ]
+      [ "(define eval (vau xs e xs))"; "(eval missing missing)" ]
+      [ "(define sequence (vau xs e xs))"; "(sequence missing)" ]
+      [ "(define begin (vau xs e xs))"; "(begin missing)" ]
+      [ "(define reset (vau xs e xs))"; "(reset missing)" ] ]
+    |> List.iter assertParitySession

--- a/IronKernel.Tests/ConformanceTests.fs
+++ b/IronKernel.Tests/ConformanceTests.fs
@@ -21,7 +21,8 @@ let ``interpreter and compiler agree on core evaluation`` () =
 let ``operative uses lexical scope and can explicitly evaluate in caller scope`` () =
     // Revised-1 Report sections 3.2 and 4.10.3.
     assertParityValueSession
-        [ "(define x 1)"
+        [ "(define list (wrap (vau xs _ xs)))"
+          "(define x 1)"
           "(define lexical (vau () _ x))"
           "(define caller-value (vau (form) caller (eval caller form)))"
           "(define exercise (wrap (vau (x) _ (list (lexical) (caller-value x)))))"
@@ -43,7 +44,8 @@ let ``environment lookup is depth first in parent order`` () =
 let ``wrapped combiner evaluates operands while operative receives syntax`` () =
     // Revised-1 Report sections 4.10.3 through 4.10.5.
     assertParityValueSession
-        [ "(define raw (vau operands _ operands))"
+        [ "(define list (wrap (vau xs _ xs)))"
+          "(define raw (vau operands _ operands))"
           "(define cooked (wrap raw))"
           "(list (raw (+ 1 2)) (cooked (+ 1 2)))" ]
         (List

--- a/IronKernel.Tests/IronKernel.Tests.fsproj
+++ b/IronKernel.Tests/IronKernel.Tests.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="EnvironmentTests.fs" />
     <Compile Include="InteropTests.fs" />
     <Compile Include="CompilerTests.fs" />
+    <Compile Include="ConformanceTests.fs" />
     <Compile Include="ContinuationTests.fs" />
     <Compile Include="StdlibTests.fs" />
     <Compile Include="ExampleTests.fs" />

--- a/IronKernel.Tests/TestHelpers.fs
+++ b/IronKernel.Tests/TestHelpers.fs
@@ -3,6 +3,7 @@ module IronKernel.Tests.TestHelpers
 open System.IO
 
 open IronKernel.Ast
+open IronKernel.Compiler
 open IronKernel.Eval
 open IronKernel.Runtime
 open IronKernel.Repl
@@ -84,6 +85,55 @@ let parseError input =
     match readExpr input with
     | Choice1Of2 _ -> ()
     | Choice2Of2 v -> failwith ("expected parse error, got " + showVal v)
+
+type EvaluationMode =
+    | Interpreted
+    | Compiled
+
+type EvaluationObservation =
+    | Returned of string
+    | Failed of string
+
+let evalRaw mode env expr =
+    let form = parseOk expr
+    let cont = newContinuation env
+    match mode with
+    | Interpreted -> eval env cont form
+    | Compiled -> evalCompiled env cont form
+
+let observe = function
+    | Choice2Of2 value -> Returned (showVal value)
+    | Choice1Of2 error -> Failed (showError error)
+
+/// Evaluate the same stateful session through both engines and compare every step.
+let assertParitySession expressions =
+    let interpretedEnv = freshEnv ()
+    let compiledEnv = freshEnv ()
+
+    expressions
+    |> List.iter (fun expr ->
+        let interpreted = evalRaw Interpreted interpretedEnv expr |> observe
+        let compiled = evalRaw Compiled compiledEnv expr |> observe
+        if interpreted <> compiled then
+            failwithf
+                "interpreter/compiler mismatch for %s\ninterpreted: %A\ncompiled: %A"
+                expr
+                interpreted
+                compiled)
+
+let assertParityValueSession expressions expected =
+    assertParitySession expressions
+
+    for mode in [Interpreted; Compiled] do
+        let env = freshEnv ()
+        let mutable result = Choice2Of2 Inert
+        for expr in expressions do
+            result <- evalRaw mode env expr
+
+        match result with
+        | Choice2Of2 actual -> assertEqv actual expected
+        | Choice1Of2 error ->
+            failwithf "%A evaluation failed: %s" mode (showError error)
 
 let repoFile relative =
     let candidates =

--- a/IronKernel/Analyze.fs
+++ b/IronKernel/Analyze.fs
@@ -25,24 +25,13 @@ module Analyze =
         | Port _
         | Status _ -> CLit value
         | List [] -> CLit (List [])
-        | List (Atom "quote" :: [x]) -> CQuote x
-        | List (Atom "if" :: [cond; a; b]) -> CIf (analyze cond, analyze a, analyze b)
-        | List (Atom "if" :: _) as form -> CResidual form
-        | List (Atom "define" :: [lhs; rhs]) -> CDefine (analyze lhs, analyze rhs)
-        | List (Atom "define" :: _) as form -> CResidual form
-        | List (Atom "vau" :: prms :: Atom envarg :: body) ->
-            CVau (prms, envarg, List.map analyze body)
-        | List (Atom "vau" :: _) as form -> CResidual form
-        | List (Atom "reset" :: [exp]) -> CReset (analyze exp)
-        | List (Atom "reset" :: _) as form -> CResidual form
-        | List (Atom "eval" :: [envE; exprE]) -> CEval (analyze envE, analyze exprE)
-        | List (Atom "eval" :: _) as form -> CResidual form
-        | List (Atom "sequence" :: body)
-        | List (Atom "begin" :: body) -> CSeq (List.map analyze body)
         | DottedList _ as form -> CResidual form
         | List (op :: args) ->
-            // Conservative: mark as applicative-style app; runtime still dispatches operatives.
-            CApp (analyze op, List.map analyze args)
+            // Kernel has no syntactically privileged operator names. Preserve operand
+            // trees exactly and let runtime binding lookup select operative semantics.
+            // Specialized forms require binding-identity guards, which this analyzer
+            // intentionally does not yet have.
+            COperate (analyze op, args)
         | other -> CResidual other
 
     let analyzeForms (forms: LispVal list) : CoreExpr list =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a reusable differential harness for interpreted and compiled evaluation
- add Kernel Report and KPLTS-derived conformance cases for scope, environments, and combiners
- preserve raw operand trees and resolve all operator semantics through runtime bindings
- cover rebinding of `if`, `quote`, `define`, `vau`, `eval`, `sequence`, `begin`, and `reset`

## Design
Kernel has no syntactically privileged operator names. The conservative analyzer now emits runtime combinations; future specialization must use binding-identity guards before recovering optimized core forms.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786898483&installation_id=147070874&pr_number=4&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F4&signature=c5b5a2b6dce30c9d7da1e6510920f8c40bfcee8e6cf259548d977a87571b89b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->