### PR TITLE
Make CLI scripts and IKC packages reliable

### DIFF
--- a/IronKernel.Tests/CliTests.fs
+++ b/IronKernel.Tests/CliTests.fs
@@ -11,7 +11,7 @@ open IronKernel.Repl
 let private tempPath extension =
     Path.Combine(Path.GetTempPath(), "ironkernel-" + Guid.NewGuid().ToString("N") + extension)
 
-let private kernelString value =
+let private kernelString (value: string) =
     "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
 
 [<Fact>]

--- a/IronKernel.Tests/CliTests.fs
+++ b/IronKernel.Tests/CliTests.fs
@@ -1,0 +1,88 @@
+module IronKernel.Tests.CliTests
+
+open System
+open System.IO
+open Xunit
+
+open IronKernel
+open IronKernel.Emit
+open IronKernel.Repl
+
+let private tempPath extension =
+    Path.Combine(Path.GetTempPath(), "ironkernel-" + Guid.NewGuid().ToString("N") + extension)
+
+let private kernelString value =
+    "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+
+[<Fact>]
+let ``script mode bootstraps the standard library`` () =
+    let script = tempPath ".scm"
+    try
+        File.WriteAllText(script, "((lambda (x) x) 42)")
+        Assert.Equal(0, runOne script [])
+    finally
+        File.Delete(script)
+
+[<Fact>]
+let ``script mode reports evaluation failure through exit code`` () =
+    let script = tempPath ".scm"
+    try
+        File.WriteAllText(script, "(missing-combiner 42)")
+        Assert.Equal(1, runOne script [])
+    finally
+        File.Delete(script)
+
+[<Fact>]
+let ``packaging validates but does not execute source`` () =
+    let script = tempPath ".scm"
+    let package = tempPath ".ikc"
+    let marker = tempPath ".txt"
+    try
+        let source =
+            sprintf "(. System.IO.File WriteAllText %s \"executed\")" (kernelString marker)
+        File.WriteAllText(script, source)
+
+        match compileFileToPackage script package with
+        | Choice1Of2 error -> failwithf "packaging failed: %A" error
+        | Choice2Of2 _ -> ()
+
+        Assert.False(File.Exists(marker), "packaging executed user code")
+
+        match loadIkc package with
+        | Choice1Of2 error -> failwithf "package execution failed: %A" error
+        | Choice2Of2 _ -> ()
+
+        Assert.Equal("executed", File.ReadAllText(marker))
+    finally
+        File.Delete(script)
+        File.Delete(package)
+        File.Delete(marker)
+
+[<Fact>]
+let ``package API requires honest ikc extension`` () =
+    let script = tempPath ".scm"
+    let output = tempPath ".dll"
+    try
+        File.WriteAllText(script, "42")
+        match compileFileToPackage script output with
+        | Choice1Of2 _ -> ()
+        | Choice2Of2 _ -> failwith "accepted a misleading .dll package name"
+    finally
+        File.Delete(script)
+        File.Delete(output)
+
+[<Fact>]
+let ``truncated package returns a structured error`` () =
+    let package = tempPath ".ikc"
+    try
+        File.WriteAllBytes(
+            package,
+            Array.concat
+                [ Text.Encoding.ASCII.GetBytes("IKC1")
+                  BitConverter.GetBytes(100) ])
+
+        match loadIkc package with
+        | Choice1Of2 _ -> ()
+        | Choice2Of2 value -> failwithf "loaded truncated package as %A" value
+    finally
+        File.Delete(package)

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -67,9 +67,9 @@ let ``compiled operative path keeps operands unevaluated`` () =
 let ``ikc emit and load`` () =
     let dir = System.IO.Path.GetTempPath()
     let src = System.IO.Path.Combine(dir, "ik-compiler-test.scm")
-    let outp = System.IO.Path.Combine(dir, "ik-compiler-test.dll")
+    let outp = System.IO.Path.Combine(dir, "ik-compiler-test.ikc")
     System.IO.File.WriteAllText(src, "(+ 20 22)")
-    match compileFileToAssembly src outp with
+    match compileFileToPackage src outp with
     | Choice1Of2 e -> failwith (showError e)
     | Choice2Of2 path ->
         Assert.True(System.IO.File.Exists path)

--- a/IronKernel.Tests/ExampleTests.fs
+++ b/IronKernel.Tests/ExampleTests.fs
@@ -16,25 +16,25 @@ let private examplesDir () =
     |> Option.defaultWith (fun () -> failwith "Examples directory not found")
 
 [<Fact>]
-let ``hello.scm compiles under bootstrap`` () =
+let ``hello.scm packages without execution`` () =
     let path = Path.Combine(examplesDir (), "hello.scm")
-    let outp = Path.Combine(Path.GetTempPath(), "hello-ci.ikc.dll")
-    match compileFileToAssembly path outp with
+    let outp = Path.Combine(Path.GetTempPath(), "hello-ci.ikc")
+    match compileFileToPackage path outp with
     | Choice1Of2 e -> failwith (showError e)
     | Choice2Of2 p -> Assert.True(File.Exists p)
 
 [<Fact>]
-let ``vau-dotnet.scm compiles under bootstrap`` () =
+let ``vau-dotnet.scm packages without execution`` () =
     let path = Path.Combine(examplesDir (), "vau-dotnet.scm")
-    let outp = Path.Combine(Path.GetTempPath(), "vau-dotnet-ci.ikc.dll")
-    match compileFileToAssembly path outp with
+    let outp = Path.Combine(Path.GetTempPath(), "vau-dotnet-ci.ikc")
+    match compileFileToPackage path outp with
     | Choice1Of2 e -> failwith (showError e)
     | Choice2Of2 p -> Assert.True(File.Exists p)
 
 [<Fact>]
-let ``samples.scm compiles under bootstrap`` () =
+let ``samples.scm packages without execution`` () =
     let path = Path.Combine(examplesDir (), "samples.scm")
-    let outp = Path.Combine(Path.GetTempPath(), "samples-ci.ikc.dll")
-    match compileFileToAssembly path outp with
+    let outp = Path.Combine(Path.GetTempPath(), "samples-ci.ikc")
+    match compileFileToPackage path outp with
     | Choice1Of2 e -> failwith (showError e)
     | Choice2Of2 p -> Assert.True(File.Exists p)

--- a/IronKernel.Tests/IronKernel.Tests.fsproj
+++ b/IronKernel.Tests/IronKernel.Tests.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="InteropTests.fs" />
     <Compile Include="CompilerTests.fs" />
     <Compile Include="ConformanceTests.fs" />
+    <Compile Include="CliTests.fs" />
     <Compile Include="ContinuationTests.fs" />
     <Compile Include="StdlibTests.fs" />
     <Compile Include="ExampleTests.fs" />

--- a/IronKernel/Emit.fs
+++ b/IronKernel/Emit.fs
@@ -5,11 +5,10 @@ module Emit =
 
     open System
     open System.IO
-    open System.Reflection
-    open System.Reflection.Emit
     open Ast
     open Errors
     open Runtime
+    open SymbolTable
     open Compiler
     open Choice
     open Eval
@@ -28,22 +27,31 @@ module Emit =
     let compileSource (source: string) : ThrowsError<KernelFunc list> =
         analyzeAndCompile source
 
-    let compileFile (path: string) : ThrowsError<KernelFunc list> =
+    let private readSource (path: string) : ThrowsError<string> =
         try
-            compileSource (File.ReadAllText path)
+            returnM (File.ReadAllText path)
         with ex -> throwError (Default ("Failed to read '" + path + "': " + ex.Message))
 
-    let private writeIkcPackage (outputPath: string) (source: string) =
-        use fs = File.Create outputPath
-        let magic = Text.Encoding.ASCII.GetBytes("IKC1")
-        fs.Write(magic, 0, magic.Length)
-        let bytes = Text.Encoding.UTF8.GetBytes source
-        let len = BitConverter.GetBytes(bytes.Length)
-        fs.Write(len, 0, len.Length)
-        fs.Write(bytes, 0, bytes.Length)
+    let compileFile (path: string) : ThrowsError<KernelFunc list> =
+        match readSource path with
+        | Choice1Of2 e -> throwError e
+        | Choice2Of2 source -> compileSource source
+
+    let private writeIkcPackage (outputPath: string) (source: string) : ThrowsError<string> =
+        try
+            use fs = File.Create outputPath
+            let magic = Text.Encoding.ASCII.GetBytes("IKC1")
+            fs.Write(magic, 0, magic.Length)
+            let bytes = Text.Encoding.UTF8.GetBytes source
+            let len = BitConverter.GetBytes(bytes.Length)
+            fs.Write(len, 0, len.Length)
+            fs.Write(bytes, 0, bytes.Length)
+            returnM outputPath
+        with ex ->
+            throwError (Default ("Failed to write '" + outputPath + "': " + ex.Message))
 
     let bootstrapEnv () =
-        let env = primitiveBindings
+        let env = makePrimitiveBindings ()
         let loadFile name =
             let path =
                 if File.Exists name then name
@@ -56,74 +64,57 @@ module Emit =
             | Choice1Of2 e -> throwError e
             | Choice2Of2 _ -> returnM env
 
-    type EmitHelpers =
-        static member RunSource(source: string) : string =
-            match bootstrapEnv () with
-            | Choice1Of2 e -> showError e
-            | Choice2Of2 env ->
-                match analyzeAndCompile source with
-                | Choice1Of2 e -> showError e
-                | Choice2Of2 forms ->
-                    match runCompiledForms env forms with
-                    | Choice1Of2 e -> showError e
-                    | Choice2Of2 v -> showVal v
+    let defaultPackagePath inputPath = Path.ChangeExtension(inputPath, ".ikc")
 
-        static member RunSourceFile(path: string) : string =
-            EmitHelpers.RunSource(File.ReadAllText path)
-
-    /// Compile a Kernel source file to an IKC1 package (.dll extension by convention).
-    let compileFileToAssembly (inputPath: string) (outputPath: string) : ThrowsError<string> =
-        match bootstrapEnv () with
-        | Choice1Of2 e -> throwError e
-        | Choice2Of2 env ->
-            match compileFile inputPath with
+    /// Validate and package Kernel source without evaluating it.
+    let compileFileToPackage (inputPath: string) (outputPath: string) : ThrowsError<string> =
+        if not (String.Equals(Path.GetExtension(outputPath), ".ikc", StringComparison.OrdinalIgnoreCase)) then
+            throwError (Default "IronKernel packages must use the .ikc extension")
+        else
+            match readSource inputPath with
             | Choice1Of2 e -> throwError e
-            | Choice2Of2 forms ->
-                match runCompiledForms env forms with
+            | Choice2Of2 source ->
+                match compileSource source with
                 | Choice1Of2 e -> throwError e
-                | Choice2Of2 _ ->
-                    let source = File.ReadAllText inputPath
+                | Choice2Of2 _ -> writeIkcPackage outputPath source
 
-                    let asmName = AssemblyName(Path.GetFileNameWithoutExtension outputPath)
-                    let asmBuilder = AssemblyBuilder.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.Run)
-                    let modBuilder = asmBuilder.DefineDynamicModule(asmName.Name)
-                    let typeBuilder = modBuilder.DefineType("IronKernelProgram", TypeAttributes.Public ||| TypeAttributes.Class)
-                    let methodBuilder =
-                        typeBuilder.DefineMethod(
-                            "Run",
-                            MethodAttributes.Public ||| MethodAttributes.Static,
-                            typeof<string>,
-                            [||])
-                    let il = methodBuilder.GetILGenerator()
-                    let runSource = typeof<EmitHelpers>.GetMethod("RunSource")
-                    il.Emit(OpCodes.Ldstr, source)
-                    il.Emit(OpCodes.Call, runSource)
-                    il.Emit(OpCodes.Ret)
-                    typeBuilder.CreateType() |> ignore
+    [<Obsolete("Use compileFileToPackage; IKC files are packages, not CLR assemblies.")>]
+    let compileFileToAssembly inputPath outputPath =
+        compileFileToPackage inputPath outputPath
 
-                    writeIkcPackage outputPath source
-                    File.WriteAllText(Path.ChangeExtension(outputPath, ".ikc"), source)
-                    returnM outputPath
+    let private readExactly (stream: Stream) count =
+        let bytes = Array.zeroCreate count
+        let mutable offset = 0
+        while offset < count do
+            let read = stream.Read(bytes, offset, count - offset)
+            if read = 0 then
+                raise (EndOfStreamException("Truncated IKC package"))
+            offset <- offset + read
+        bytes
 
-    let loadIkc (path: string) : ThrowsError<LispVal> =
+    let loadIkcWithArgs (path: string) (args: string list) : ThrowsError<LispVal> =
         try
             use fs = File.OpenRead path
-            let magic = Array.zeroCreate 4
-            if fs.Read(magic, 0, 4) <> 4 then throwError (Default "Truncated IKC package")
-            elif Text.Encoding.ASCII.GetString magic <> "IKC1" then
+            let magic = readExactly fs 4
+            if Text.Encoding.ASCII.GetString magic <> "IKC1" then
                 throwError (Default "Not an IronKernel compiled package (missing IKC1 header)")
             else
-                let lenBytes = Array.zeroCreate 4
-                fs.Read(lenBytes, 0, 4) |> ignore
+                let lenBytes = readExactly fs 4
                 let len = BitConverter.ToInt32(lenBytes, 0)
-                let bytes = Array.zeroCreate len
-                fs.Read(bytes, 0, len) |> ignore
-                let source = Text.Encoding.UTF8.GetString bytes
-                match bootstrapEnv () with
-                | Choice1Of2 e -> throwError e
-                | Choice2Of2 env ->
-                    match compileSource source with
+                if len < 0 || int64 len > fs.Length - fs.Position then
+                    throwError (Default "Truncated IKC package")
+                else
+                    let source = readExactly fs len |> Text.Encoding.UTF8.GetString
+                    match bootstrapEnv () with
                     | Choice1Of2 e -> throwError e
-                    | Choice2Of2 forms -> runCompiledForms env forms
+                    | Choice2Of2 standardEnv ->
+                        let env =
+                            bindVars standardEnv
+                                [ "args", List (List.map (fun arg -> Obj(arg :> obj)) args) ]
+                        match compileSource source with
+                        | Choice1Of2 e -> throwError e
+                        | Choice2Of2 forms -> runCompiledForms env forms
         with
-        | :? IOException as ex -> throwError (Default ex.Message)
+        | :? IOException as ex -> throwError (Default ("Failed to load '" + path + "': " + ex.Message))
+
+    let loadIkc path = loadIkcWithArgs path []

--- a/IronKernel/Program.fs
+++ b/IronKernel/Program.fs
@@ -18,7 +18,7 @@ let private usageError message =
     eprintfn "%s\n\n%s" message usage
     2
 
-let private runPackage path args =
+let private runPackage (path: string) (args: string list) =
     match loadIkcWithArgs path args with
     | Choice1Of2 error ->
         eprintfn "Package error: %s" (showError error)
@@ -28,7 +28,7 @@ let private runPackage path args =
         printfn "%s" (showVal value)
         0
 
-let private runPath path args =
+let private runPath (path: string) (args: string list) =
     if String.Equals(Path.GetExtension(path), ".ikc", StringComparison.OrdinalIgnoreCase) then
         runPackage path args
     else

--- a/IronKernel/Program.fs
+++ b/IronKernel/Program.fs
@@ -1,26 +1,68 @@
 ﻿open System
+open System.IO
 open IronKernel.Repl
 open IronKernel.Emit
+open IronKernel.Ast
+open IronKernel.Errors
+
+let private usage =
+    """Usage:
+  ironkernel                         Start the REPL
+  ironkernel <file.scm> [args...]    Run a source script
+  ironkernel run <file> [args...]    Run a .scm script or .ikc package
+  ironkernel compile <file.scm> [-o <file.ikc>]
+  ironkernel --help
+  ironkernel --version"""
+
+let private usageError message =
+    eprintfn "%s\n\n%s" message usage
+    2
+
+let private runPackage path args =
+    match loadIkcWithArgs path args with
+    | Choice1Of2 error ->
+        eprintfn "Package error: %s" (showError error)
+        1
+    | Choice2Of2 Inert -> 0
+    | Choice2Of2 value ->
+        printfn "%s" (showVal value)
+        0
+
+let private runPath path args =
+    if String.Equals(Path.GetExtension(path), ".ikc", StringComparison.OrdinalIgnoreCase) then
+        runPackage path args
+    else
+        runOne path args
 
 [<EntryPoint>]
 let main argv =
     match Array.toList argv with
-    | [] ->
-        runRepl ()
+    | [] -> runRepl ()
+    | ["--help"] | ["-h"] | ["help"] ->
+        printfn "%s" usage
         0
+    | ["--version"] | ["-V"] ->
+        printfn "IronKernel %s" version
+        0
+    | ["run"] -> usageError "Missing file for 'run'."
+    | "run" :: path :: args -> runPath path args
+    | ["compile"] -> usageError "Missing source file for 'compile'."
     | "compile" :: input :: rest ->
-        let output =
+        let outputResult =
             match rest with
-            | ["-o"; path] | ["--output"; path] -> path
-            | [path] when not (path.StartsWith("-")) -> path
-            | _ -> System.IO.Path.ChangeExtension(input, ".dll")
-        match compileFileToAssembly input output with
-        | Choice2Of2 path ->
-            printfn "Wrote %s" path
-            0
-        | Choice1Of2 err ->
-            eprintfn "Compile error: %s" (IronKernel.Errors.showError err)
-            1
-    | filename :: args ->
-        runOne filename args
-        0
+            | [] -> Choice2Of2 (defaultPackagePath input)
+            | ["-o"; path] | ["--output"; path] -> Choice2Of2 path
+            | _ -> Choice1Of2 "Expected only '-o <file.ikc>' after the source file."
+        match outputResult with
+        | Choice1Of2 message -> usageError message
+        | Choice2Of2 output ->
+            match compileFileToPackage input output with
+            | Choice2Of2 path ->
+                printfn "Wrote %s" path
+                0
+            | Choice1Of2 err ->
+                eprintfn "Compile error: %s" (showError err)
+                1
+    | option :: _ when option.StartsWith("-") ->
+        usageError ("Unknown option: " + option)
+    | filename :: args -> runPath filename args

--- a/IronKernel/Repl.fs
+++ b/IronKernel/Repl.fs
@@ -11,6 +11,7 @@ module Repl =
     open Choice
     open Runtime
     open Compiler
+    open Emit
     open Mono.Terminal
     open System.Text
 
@@ -45,12 +46,20 @@ module Repl =
             loop ()
       loop ()
 
-    let runOne filename (args:string list) = 
-        let env = bindVars primitiveBindings [ "args", List (List.map (fun x -> Ast.Obj( x :> obj)) args) ]
-        either { 
-            let! p = eval env (newContinuation env) (List [Atom "load"; Ast.Obj filename]) 
-            return (p |> showVal |> flushStr)
-            } |> ignore
+    let runOne filename (args:string list) =
+        match bootstrapEnv () with
+        | Choice1Of2 error ->
+            eprintfn "Startup error: %s" (showError error)
+            1
+        | Choice2Of2 standardEnv ->
+            let env =
+                bindVars standardEnv
+                    [ "args", List (List.map (fun x -> Ast.Obj(x :> obj)) args) ]
+            match eval env (newContinuation env) (List [Atom "load"; Ast.Obj(filename :> obj)]) with
+            | Choice1Of2 error ->
+                eprintfn "Script error: %s" (showError error)
+                1
+            | Choice2Of2 _ -> 0
 
     let version = "0.2.0-net10"
 
@@ -58,19 +67,18 @@ module Repl =
         putStrLn ""
         putStrLn (sprintf " IronKernel v%s" version)
         putStrLn " Full-Kernel hybrid CLR compiler"
-        putStrLn " https://github.com/ademar/IronKernel"
+        putStrLn " https://github.com/ironkernel-lang/IronKernel"
         putStrLn ""
-
-    let internal run = evalAndPrint primitiveBindings (newContinuation primitiveBindings)
-
-    let play s =
-        putStrLn ("IronKernel> " + s)
-        run s
 
     let runRepl _ =
         Console.OutputEncoding <- Encoding.UTF8
         showBanner ()
-        play "(load \"kernel.scm\")"
-        play "(load \"promises.scm\")"
-        until (fun x -> x.ToLower().Equals("quit")) 
-            (readPrompt "IronKernel> ") run
+        match bootstrapEnv () with
+        | Choice1Of2 error ->
+            eprintfn "Startup error: %s" (showError error)
+            1
+        | Choice2Of2 env ->
+            let run = evalAndPrint env (newContinuation env)
+            until (fun x -> x.ToLowerInvariant().Equals("quit"))
+                (readPrompt "IronKernel> ") run
+            0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ IronKernel is a dialect of [John N. Shutt’s Kernel](http://web.cs.wpi.edu/~jsh
 
 Kernel is Scheme-like but more homoiconic: combiners and environments are first-class, and the core abstraction is the operative (`vau`) rather than macros.
 
-This tree is a **hybrid CLR compiler**: programs are analyzed to a Core IR, lowered through Expression trees where safe, and fall back to a trampolined CPS interpreter for full Kernel semantics (`vau`, first-class `eval`/environments, `call/cc`, `shift`/`reset`).
+This tree is a **hybrid CLR runtime**: programs are analyzed to a Core IR and compiled to CLR delegates while preserving runtime combiner dispatch, with a trampolined CPS interpreter for full Kernel semantics (`vau`, first-class `eval`/environments, `call/cc`, `shift`/`reset`).
 
 ## Build & test
 
@@ -39,13 +39,31 @@ dotnet run --project IronKernel
 
 Loads `kernel.scm` and `promises.scm`, then presents an interactive prompt. Type `quit` to exit.
 
+## Run a script
+
+```bash
+dotnet run --project IronKernel -- path/to/program.scm arg1 arg2
+# Equivalent explicit form:
+dotnet run --project IronKernel -- run path/to/program.scm arg1 arg2
+```
+
+Script mode loads `kernel.scm` and `promises.scm` in a fresh environment, then
+binds command-line arguments to `args`. Evaluation and startup errors are written
+to stderr and produce a non-zero exit code.
+
 ## Compile to an IKC package
 
 ```bash
-dotnet run --project IronKernel -- compile path/to/program.scm -o program.dll
+dotnet run --project IronKernel -- compile path/to/program.scm -o program.ikc
+dotnet run --project IronKernel -- run program.ikc
 ```
 
-Writes an **IKC1** package (Kernel source payload + in-process `Reflection.Emit` runner type). Reload with the runtime helpers in `IronKernel.Emit`.
+Compilation validates and packages the source without executing it. An **IKC1**
+file is an IronKernel package containing the source payload; it is not a CLR
+assembly. At run time IronKernel loads the standard library, compiles the payload
+to delegates, and executes it. Omitting `-o` writes `<source-name>.ikc`.
+
+Use `--help` for all commands and `--version` for the runtime version.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- bootstrap scripts in fresh standard environments and propagate failures as exit codes
- add `run`, `--help`, and `--version` CLI behavior
- package source as `.ikc` without executing it during compilation
- support package arguments, harden package reads, and document the IKC lifecycle
- retain the obsolete assembly-named API as a compatibility wrapper

## Validation
- focused CLI/package/example tests pass
- full Debug and Release suites pass (62 tests)
- direct script and packaged `hello.scm` both run successfully
- missing scripts return exit code 1

## Design
IKC files are explicitly source packages—not CLR assemblies—and are compiled to delegates when run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786902317&installation_id=147070874&pr_number=5&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F5&signature=317098cf21feca67d4b5f1835d2050ac51e58ad07563f9ad91dd87902ed39b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->