### PR TITLE
Add source diagnostics and first-run onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,9 @@ Kernel language (`IronKernel.sln`, projects `IronKernel`, `IronKernel.Tests`,
   `dotnet build` are the lint signal (the build currently has warnings, 0 errors).
 
 ### REPL gotchas (non-obvious)
-- `dotnet run --project IronKernel` loads `kernel.scm` and `promises.scm` using
-  paths **relative to the current working directory**. Run it from the
-  `IronKernel/` directory (where those files live) or from a build output dir
-  that contains them. Running from the repo root fails with
-  `File not found: 'kernel.scm'`.
+- `dotnet run --project IronKernel` loads `kernel.scm` and `promises.scm` from
+  the current directory when present, then falls back to the application output
+  directory. Running from the repository root is supported.
 - The REPL uses the `Mono.Terminal` line editor, which needs a **real TTY**.
   Piping stdin (`printf ... | dotnet run`) crashes with a `System.Console`
   `SetCursorPosition` exception. For scripted/interactive REPL testing, drive it
@@ -35,6 +33,7 @@ Kernel language (`IronKernel.sln`, projects `IronKernel`, `IronKernel.Tests`,
 
 ### Running scripts / compiling
 - Run a script file: `dotnet run --project IronKernel -- path/to/file.scm`
-  (this `load`s the file but does **not** auto-load the stdlib).
+  (script and package modes auto-load the standard library).
 - Compile to an IKC package:
-  `dotnet run --project IronKernel -- compile file.scm -o out.dll`.
+  `dotnet run --project IronKernel -- compile file.scm -o out.ikc`.
+- Run a package: `dotnet run --project IronKernel -- run out.ikc`.

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,0 +1,34 @@
+# IronKernel examples
+
+Run an example from the repository root:
+
+```bash
+dotnet run --project IronKernel -- Examples/hello.scm
+```
+
+The CLI loads `kernel.scm` and `promises.scm` before each script. Compile any
+finite example to an `.ikc` package with:
+
+```bash
+dotnet run --project IronKernel -- compile Examples/hello.scm -o hello.ikc
+dotnet run --project IronKernel -- run hello.ikc
+```
+
+| Example | Demonstrates | Notes |
+|---|---|---|
+| `hello.scm` | Environments, `lambda`, and CLR output | Prints `Hello,world!` |
+| `vau-dotnet.scm` | User-defined control forms and .NET interop | Guided feature tour |
+| `samples.scm` | Recursion and the `let` family | Prints intermediate values |
+| `continuations.scm` | Full continuations | Defines local output helpers |
+| `coroutines.scm` | Cooperative scheduling experiment | Historical example; not yet covered by the compatibility suite |
+| `zipper.scm` | Delimited continuations | Functional zipper traversal |
+| `sqrt.scm` | Operative-based numeric procedure | Defines `sqrt`; intentionally produces no output |
+| `yingyang.scm` | Classic yin-yang continuation loop | Intentionally non-terminating; do not use it to test packaging |
+
+Errors identify the source file and failing range:
+
+```text
+Examples/demo.scm:2:1: Getting an unbound variable: 'missing'
+(missing 42)
+^^^^^^^^^^^^
+```

--- a/IronKernel.Tests/CliTests.fs
+++ b/IronKernel.Tests/CliTests.fs
@@ -5,6 +5,7 @@ open System.IO
 open Xunit
 
 open IronKernel
+open IronKernel.Errors
 open IronKernel.Emit
 open IronKernel.Repl
 
@@ -85,4 +86,35 @@ let ``truncated package returns a structured error`` () =
         | Choice1Of2 _ -> ()
         | Choice2Of2 value -> failwithf "loaded truncated package as %A" value
     finally
+        File.Delete(package)
+
+[<Fact>]
+let ``runtime diagnostics identify the failing top-level form`` () =
+    match bootstrapEnv () with
+    | Choice1Of2 error -> failwith (showError error)
+    | Choice2Of2 env ->
+        let source = "(define ready #t)\n(missing-combiner 42)"
+        match runSource env "runtime-error.scm" source with
+        | Choice2Of2 value -> failwithf "unexpectedly returned %A" value
+        | Choice1Of2 error ->
+            let diagnostic = showError error
+            Assert.Contains("runtime-error.scm:2:1", diagnostic)
+            Assert.Contains("(missing-combiner 42)", diagnostic)
+            Assert.Contains("^^^^", diagnostic)
+
+[<Fact>]
+let ``package validation reports named parse diagnostics`` () =
+    let script = tempPath ".scm"
+    let package = tempPath ".ikc"
+    try
+        File.WriteAllText(script, "(define broken")
+        match compileFileToPackage script package with
+        | Choice2Of2 _ -> failwith "packaged invalid source"
+        | Choice1Of2 error ->
+            let diagnostic = showError error
+            Assert.Contains(script + ":1:", diagnostic)
+            Assert.Contains("(define broken", diagnostic)
+            Assert.Contains("^", diagnostic)
+    finally
+        File.Delete(script)
         File.Delete(package)

--- a/IronKernel.Tests/ParserTests.fs
+++ b/IronKernel.Tests/ParserTests.fs
@@ -2,6 +2,9 @@ module IronKernel.Tests.ParserTests
 
 open Xunit
 open IronKernel.Ast
+open IronKernel.Errors
+open IronKernel.Parser
+open IronKernel.Source
 open IronKernel.Tests.TestHelpers
 
 [<Fact>]
@@ -60,3 +63,32 @@ let ``parses nested combinations`` () =
 [<Fact>]
 let ``rejects unbalanced parentheses`` () =
     parseError "(+ 1 2"
+
+[<Fact>]
+let ``located parser records nested source spans without changing datum`` () =
+    let source = "(+ 1\n  (* 2 3))"
+    match readLocatedExpr "nested.scm" source with
+    | Choice1Of2 error -> failwith (showError error)
+    | Choice2Of2 outer ->
+        assertEqv (toLispVal outer) (parseOk source)
+        Assert.Equal("nested.scm", outer.span.sourceName)
+        Assert.Equal(1L, outer.span.startPosition.line)
+        Assert.Equal(1L, outer.span.startPosition.column)
+        Assert.Equal(2L, outer.span.endPosition.line)
+        match outer.kind with
+        | LList [_; _; inner] ->
+            Assert.True(contains outer.span inner.span)
+            Assert.Equal(2L, inner.span.startPosition.line)
+            Assert.Equal(3L, inner.span.startPosition.column)
+        | _ -> failwith "expected nested list"
+
+[<Fact>]
+let ``named parse diagnostics include position source and caret`` () =
+    let source = "(+ 1\n  (* 2 3)"
+    match readExprFromSource "broken.scm" source with
+    | Choice2Of2 value -> failwith ("unexpectedly parsed " + showVal value)
+    | Choice1Of2 error ->
+        let diagnostic = showError error
+        Assert.Contains("broken.scm:2:", diagnostic)
+        Assert.Contains("(* 2 3)", diagnostic)
+        Assert.Contains("^", diagnostic)

--- a/IronKernel/Ast.fs
+++ b/IronKernel/Ast.fs
@@ -2,6 +2,18 @@
 
 module Ast =
 
+    type SourcePosition = {
+        offset : int64
+        line : int64
+        column : int64
+    }
+
+    type SourceSpan = {
+        sourceName : string
+        startPosition : SourcePosition
+        endPosition : SourcePosition
+    }
+
     type ContinuationType = Full | Delimited
 
     /// Trampoline step used by the CPS evaluator / compiler runtime.
@@ -65,6 +77,7 @@ module Ast =
        | UnboundVar of string*string
        | Default of string
        | ClrException of System.Exception
+       | LocatedError of SourceSpan * string option * LispError
 
     and ThrowsError<'a> = Choice<LispError,'a>
 

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -11,7 +11,6 @@ module Compiler =
     open Errors
     open Ir
     open Analyze
-    open Source
     open Eval
     open Choice
 
@@ -159,7 +158,7 @@ module Compiler =
         | Choice2Of2 forms ->
             forms
             |> List.map (fun form ->
-                { func = compileLispVal (toLispVal form)
-                  span = spanOf form
-                  sourceLine = sourceLineAt source form.span.startPosition.line })
+                { func = compileLispVal (Source.toLispVal form)
+                  span = Source.spanOf form
+                  sourceLine = Source.sourceLineAt source form.span.startPosition.line })
             |> returnM

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -11,6 +11,7 @@ module Compiler =
     open Errors
     open Ir
     open Analyze
+    open Source
     open Eval
     open Choice
 
@@ -145,3 +146,20 @@ module Compiler =
         match Parser.readExprList source with
         | Choice1Of2 e -> throwError e
         | Choice2Of2 forms -> returnM (compileForms forms)
+
+    type LocatedKernelFunc = {
+        func : KernelFunc
+        span : SourceSpan
+        sourceLine : string option
+    }
+
+    let analyzeAndCompileLocated sourceName (source: string) : ThrowsError<LocatedKernelFunc list> =
+        match Parser.readLocatedExprList sourceName source with
+        | Choice1Of2 e -> throwError e
+        | Choice2Of2 forms ->
+            forms
+            |> List.map (fun form ->
+                { func = compileLispVal (toLispVal form)
+                  span = spanOf form
+                  sourceLine = sourceLineAt source form.span.startPosition.line })
+            |> returnM

--- a/IronKernel/Emit.fs
+++ b/IronKernel/Emit.fs
@@ -24,8 +24,24 @@ module Emit =
                 | Choice2Of2 v -> loop rest v
         loop forms Inert
 
+    let runLocatedForms (env: LispVal) (forms: LocatedKernelFunc list) : ThrowsError<LispVal> =
+        let cont = newContinuation env
+        let rec loop remaining last =
+            match remaining with
+            | [] -> returnM last
+            | form :: rest ->
+                match form.func.Invoke(env, cont) with
+                | Choice1Of2 (LocatedError _ as error) -> throwError error
+                | Choice1Of2 error ->
+                    throwError (LocatedError(form.span, form.sourceLine, error))
+                | Choice2Of2 value -> loop rest value
+        loop forms Inert
+
     let compileSource (source: string) : ThrowsError<KernelFunc list> =
         analyzeAndCompile source
+
+    let compileSourceLocated sourceName source =
+        analyzeAndCompileLocated sourceName source
 
     let private readSource (path: string) : ThrowsError<string> =
         try
@@ -35,7 +51,20 @@ module Emit =
     let compileFile (path: string) : ThrowsError<KernelFunc list> =
         match readSource path with
         | Choice1Of2 e -> throwError e
-        | Choice2Of2 source -> compileSource source
+        | Choice2Of2 source ->
+            match compileSourceLocated path source with
+            | Choice1Of2 e -> throwError e
+            | Choice2Of2 forms -> forms |> List.map (fun form -> form.func) |> returnM
+
+    let runSource (env: LispVal) sourceName source =
+        match compileSourceLocated sourceName source with
+        | Choice1Of2 e -> throwError e
+        | Choice2Of2 forms -> runLocatedForms env forms
+
+    let runSourceFile (env: LispVal) path =
+        match readSource path with
+        | Choice1Of2 e -> throwError e
+        | Choice2Of2 source -> runSource env path source
 
     let private writeIkcPackage (outputPath: string) (source: string) : ThrowsError<string> =
         try
@@ -74,7 +103,7 @@ module Emit =
             match readSource inputPath with
             | Choice1Of2 e -> throwError e
             | Choice2Of2 source ->
-                match compileSource source with
+                match compileSourceLocated inputPath source with
                 | Choice1Of2 e -> throwError e
                 | Choice2Of2 _ -> writeIkcPackage outputPath source
 
@@ -111,9 +140,7 @@ module Emit =
                         let env =
                             bindVars standardEnv
                                 [ "args", List (List.map (fun arg -> Obj(arg :> obj)) args) ]
-                        match compileSource source with
-                        | Choice1Of2 e -> throwError e
-                        | Choice2Of2 forms -> runCompiledForms env forms
+                        runSource env path source
         with
         | :? IOException as ex -> throwError (Default ("Failed to load '" + path + "': " + ex.Message))
 

--- a/IronKernel/Errors.fs
+++ b/IronKernel/Errors.fs
@@ -13,16 +13,35 @@ module Errors =
         |Choice1Of2(error) -> f error
         |Choice2Of2(result) -> action
 
-    let showError = function
+    let rec showError = function
         | UnboundVar(msg,varname) -> msg + ": '" + varname + "' "
         | BadSpecialForm(msg,form) -> msg + ": " + showVal form
         | NotFunction(msg,func) -> msg + ": " + func
         | NumArgs(expected,found) -> "Expected " + expected.ToString()  + " args, found values " + unwordsList found
         | TypeMismatch(expected,found) -> "Invalid type: expected " + expected  + ", found " + showVal found
         | ClrTypeMismatch(expected,found) -> "Invalid type: expected " + expected  + ", found " + found
-        | Parser(parseError) -> "Parse error at " + parseError
+        | Parser(parseError) -> "Parse error: " + parseError
         | Default(msg) -> msg
-        | ClrException ex -> ex.Message 
+        | ClrException ex -> ex.Message
+        | LocatedError(span, sourceLine, error) ->
+            let source =
+                if String.IsNullOrWhiteSpace span.sourceName then "<input>"
+                else span.sourceName
+            let position = span.startPosition
+            let header =
+                sprintf "%s:%d:%d: %s" source position.line position.column (showError error)
+            match sourceLine with
+            | None -> header
+            | Some line ->
+                let indent = String(' ', max 0 (int position.column - 1))
+                let requestedWidth =
+                    if span.endPosition.line = position.line then
+                        int (span.endPosition.column - position.column)
+                    else 1
+                let availableWidth = max 1 (line.Length - indent.Length)
+                let width = min availableWidth (max 1 requestedWidth)
+                header + Environment.NewLine + line + Environment.NewLine
+                + indent + String('^', width)
 
     let trapError (action:ThrowsError<LispVal>) : ThrowsError<LispVal> = 
         catchError action (fun x -> succeed (Ast.Status(showError x)))

--- a/IronKernel/IronKernel.fsproj
+++ b/IronKernel/IronKernel.fsproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Compile Include="Monads.fs" />
     <Compile Include="Ast.fs" />
+    <Compile Include="Source.fs" />
     <Compile Include="Errors.fs" />
     <Compile Include="Parser.fs" />
     <Compile Include="SymbolTable.fs" />

--- a/IronKernel/Parser.fs
+++ b/IronKernel/Parser.fs
@@ -1,16 +1,17 @@
 ﻿namespace IronKernel
 
 module Parser =
-    
+
     open FParsec
     open Ast
     open Errors
-    
+    open Source
+
     let symbol : Parser<char,unit> = anyOf  "!#$%|*+-/:<=>?@^_~."
 
     let comment = pchar ';' >>. restOfLine true
     let whiteSpace = anyOf " \t\r\n" |>> fun x -> string x
-    
+
     let ws  = skipMany  (whiteSpace <|> comment)
     let ws1 = skipMany1 (whiteSpace <|> comment)
 
@@ -26,23 +27,23 @@ module Parser =
         between (pstring "\"") (pstring "\"")
                 (stringsSepBy normalCharSnippet escapedChar)
 
-    
-    let parseString  : Parser<LispVal,unit> = stringLiteral |>> makeObj 
+
+    let parseString  : Parser<LispVal,unit> = stringLiteral |>> makeObj
 
     let parseAtom : Parser<LispVal,unit> =
         parse {
             let! first = letter <|> symbol
             let! rest = manyChars (letter <|> digit <|> symbol)
-            
+
             return
                 if first.Equals(':') then Keyword rest
                 else
                     let atom = first.ToString() + rest
-                    match atom with 
+                    match atom with
                     | "#t" -> Bool(true)
                     | "#f" -> Bool(false)
                     | "#inert" -> Inert
-                    | _    -> Atom atom } 
+                    | _    -> Atom atom }
 
     // We want to support decimal or hexadecimal numbers with an optional minus
     // sign. Integers may have an 'L' suffix to indicate that the number should
@@ -51,7 +52,7 @@ module Parser =
                        ||| NumberLiteralOptions.AllowFraction
                        ||| NumberLiteralOptions.AllowExponent
                        ||| NumberLiteralOptions.AllowHexadecimal
-                       ||| NumberLiteralOptions.AllowSuffix 
+                       ||| NumberLiteralOptions.AllowSuffix
 
     let pnumber : Parser<LispVal, unit> =
         let parser = numberLiteral numberFormat "number"
@@ -85,50 +86,126 @@ module Parser =
             else // reconstruct error reply
                 Reply(reply.Status, reply.Error)
 
-    let parseNumber = pnumber 
-   
-    let rec parseList : Parser<LispVal,unit> = (sepEndBy (parseExpr) ws1)  |>> List
-    and parseArray : Parser<LispVal,unit> = (sepEndBy (parseExpr) ws1)  |>> (fun xx -> List.toArray xx |> Vector)
-    and parseDottedList :  Parser<LispVal,unit> = 
-        parse {
-            let! head = endBy parseExpr spaces1
-            let! tail = skipChar '&' >>. spaces1 >>. parseExpr
-            return DottedList(head,tail)
-        }
-    
-    and parseQuoted : Parser<LispVal,unit> =
-        parse {
-            do! skipChar '\''
-            let! x = parseExpr
-            return List [Atom("quote");x]
-        } 
+    let parseNumber = pnumber
 
-    and parseExpr : Parser<LispVal,unit> = 
-        parseString
-        <|> parseNumber
-        <|> parseAtom
-        <|> parseQuoted
+    let private sourcePosition (position: FParsec.Position) : SourcePosition =
+        { offset = position.Index
+          line = position.Line
+          column = position.Column }
+
+    let private sourceSpan (startPosition: FParsec.Position) (endPosition: FParsec.Position) =
+        { sourceName = startPosition.StreamName
+          startPosition = sourcePosition startPosition
+          endPosition = sourcePosition endPosition }
+
+    let private locatedDatum parser : Parser<LocatedValue, unit> =
+        parse {
+            let! startPosition = getPosition
+            let! value = parser
+            let! endPosition = getPosition
+            let kind =
+                match value with
+                | Atom name -> LAtom name
+                | other -> LLiteral other
+            return { kind = kind; span = sourceSpan startPosition endPosition }
+        }
+
+    let parseLocatedString = locatedDatum parseString
+    let parseLocatedNumber = locatedDatum parseNumber
+    let parseLocatedAtom = locatedDatum parseAtom
+
+    let rec parseLocatedList : Parser<LocatedValue list,unit> =
+        sepEndBy parseLocatedExpr ws1
+    and parseLocatedArray : Parser<LocatedValue array,unit> =
+        sepEndBy parseLocatedExpr ws1 |>> List.toArray
+    and parseLocatedDottedList : Parser<LocatedValue list * LocatedValue,unit> =
+        parse {
+            let! head = endBy parseLocatedExpr spaces1
+            let! tail = skipChar '&' >>. spaces1 >>. parseLocatedExpr
+            return head, tail
+        }
+    and parseLocatedQuoted : Parser<LocatedValue,unit> =
+        parse {
+            let! startPosition = getPosition
+            do! skipChar '\''
+            let! quoted = parseLocatedExpr
+            let! endPosition = getPosition
+            return
+                { kind = LQuote quoted
+                  span = sourceSpan startPosition endPosition }
+        }
+    and parseLocatedExpr : Parser<LocatedValue,unit> =
+        parseLocatedString
+        <|> parseLocatedNumber
+        <|> parseLocatedAtom
+        <|> parseLocatedQuoted
         <|> parse {
-                do! ws
+                let! startPosition = getPosition
                 do! skipChar '('
                 do! ws
-                let! x = (attempt parseDottedList) <|> parseList
+                let! kind =
+                    (attempt parseLocatedDottedList |>> LDottedList)
+                    <|> (parseLocatedList |>> LList)
                 do! skipChar ')'
-                return x
+                let! endPosition = getPosition
+                return
+                    { kind = kind
+                      span = sourceSpan startPosition endPosition }
             }
         <|> parse {
-                do! ws
+                let! startPosition = getPosition
                 do! skipChar '['
                 do! ws
-                let! x = parseArray
+                let! values = parseLocatedArray
                 do! skipChar ']'
-                return x
+                let! endPosition = getPosition
+                return
+                    { kind = LVector values
+                      span = sourceSpan startPosition endPosition }
             }
-        
-    let readOrThrow parser input = 
-        match run parser input  with
-        |Success(result,_,_) -> Choice2Of2(result)
-        |Failure(err,_,_) -> throwError <| Parser(err) 
 
-    let readExpr = readOrThrow parseExpr
-    let readExprList = readOrThrow  (endBy parseExpr ws)
+    let parseExpr : Parser<LispVal, unit> = parseLocatedExpr |>> toLispVal
+
+    let private conciseParseMessage (message: string) =
+        let lines = message.Replace("\r\n", "\n").Split('\n')
+        match
+            lines
+            |> Array.tryFindIndex (fun line ->
+                line.StartsWith("Expecting", System.StringComparison.Ordinal)
+                || line.StartsWith("Unexpected", System.StringComparison.Ordinal)
+                || line.StartsWith("The parser", System.StringComparison.Ordinal))
+        with
+        | Some index -> System.String.Join(System.Environment.NewLine, lines.[index..])
+        | None -> "invalid syntax"
+
+    let private readLocatedOrThrow parser sourceName input =
+        match runParserOnString parser () sourceName input with
+        | Success(result,_,_) -> Choice2Of2 result
+        | Failure(message, parserError, _) ->
+            let position = parserError.Position
+            let point = sourcePosition position
+            let span =
+                { sourceName = position.StreamName
+                  startPosition = point
+                  endPosition = point }
+            let line = sourceLineAt input position.Line
+            throwError (LocatedError(span, line, Parser(conciseParseMessage message)))
+
+    let readLocatedExpr sourceName input =
+        readLocatedOrThrow (ws >>. parseLocatedExpr .>> ws .>> eof) sourceName input
+
+    let readLocatedExprList sourceName input =
+        readLocatedOrThrow (ws >>. many (parseLocatedExpr .>> ws) .>> eof) sourceName input
+
+    let readExprFromSource sourceName input =
+        match readLocatedExpr sourceName input with
+        | Choice1Of2 error -> throwError error
+        | Choice2Of2 value -> succeed (toLispVal value)
+
+    let readExprListFromSource sourceName input =
+        match readLocatedExprList sourceName input with
+        | Choice1Of2 error -> throwError error
+        | Choice2Of2 values -> values |> List.map toLispVal |> succeed
+
+    let readExpr = readExprFromSource ""
+    let readExprList = readExprListFromSource ""

--- a/IronKernel/Repl.fs
+++ b/IronKernel/Repl.fs
@@ -55,7 +55,7 @@ module Repl =
             let env =
                 bindVars standardEnv
                     [ "args", List (List.map (fun x -> Ast.Obj(x :> obj)) args) ]
-            match eval env (newContinuation env) (List [Atom "load"; Ast.Obj(filename :> obj)]) with
+            match runSourceFile env filename with
             | Choice1Of2 error ->
                 eprintfn "Script error: %s" (showError error)
                 1

--- a/IronKernel/Runtime.fs
+++ b/IronKernel/Runtime.fs
@@ -123,7 +123,7 @@
 
         let load filename = either{
                 let! Obj(q) = tryLoad filename
-                return! readExprList (string q)
+                return! readExprListFromSource filename (string q)
                 }
 
         let readAll [Obj filename] = 

--- a/IronKernel/Source.fs
+++ b/IronKernel/Source.fs
@@ -1,0 +1,41 @@
+namespace IronKernel
+
+module Source =
+
+    open Ast
+
+    type LocatedValue = {
+        kind : LocatedValueKind
+        span : SourceSpan
+    }
+
+    and LocatedValueKind =
+        | LAtom of string
+        | LList of LocatedValue list
+        | LDottedList of LocatedValue list * LocatedValue
+        | LVector of LocatedValue array
+        | LLiteral of LispVal
+        | LQuote of LocatedValue
+
+    let spanOf value = value.span
+
+    let rec toLispVal value =
+        match value.kind with
+        | LAtom name -> Atom name
+        | LList values -> List (List.map toLispVal values)
+        | LDottedList (head, tail) ->
+            DottedList (List.map toLispVal head, toLispVal tail)
+        | LVector values -> Vector (Array.map toLispVal values)
+        | LLiteral literal -> literal
+        | LQuote quoted -> List [Atom "quote"; toLispVal quoted]
+
+    let sourceLineAt (source: string) (line: int64) =
+        if line < 1L then None
+        else
+            source.Replace("\r\n", "\n").Split('\n')
+            |> Array.tryItem (int line - 1)
+
+    let contains outer inner =
+        outer.sourceName = inner.sourceName
+        && outer.startPosition.offset <= inner.startPosition.offset
+        && outer.endPosition.offset >= inner.endPosition.offset

--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ python3 -m http.server -d website 8080
 
 GitHub Pages deploys from `website/` via `.github/workflows/pages.yml` (enable Pages → “GitHub Actions” in repo settings, then point the domain’s DNS at GitHub).
 
+## Getting started
+
+With the .NET 10 SDK:
+
+```bash
+dotnet build
+dotnet run --project IronKernel -- Examples/hello.scm
+```
+
+For a release archive, extract it and run `./IronKernel` (`IronKernel.exe` on
+Windows) from the extracted directory. The archive includes the standard
+library files required by the runtime.
+
+See the [getting-started guide](website/docs/getting-started.html) for the full
+REPL, script, and package workflow, and [`Examples/README.md`](Examples/README.md)
+for runnable programs.
+
 ## REPL
 
 ```bash
@@ -64,6 +81,18 @@ assembly. At run time IronKernel loads the standard library, compiles the payloa
 to delegates, and executes it. Omitting `-o` writes `<source-name>.ikc`.
 
 Use `--help` for all commands and `--version` for the runtime version.
+
+## Diagnostics
+
+Parse and runtime failures include the source path, line and column, offending
+line, and a caret range. CLI modes write diagnostics to stderr and return a
+non-zero exit code:
+
+```text
+program.scm:2:1: Getting an unbound variable: 'missing'
+(missing 42)
+^^^^^^^^^^^^
+```
 
 ## Syntax
 

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -240,13 +240,22 @@ img {
   margin: 0 0 2rem;
 }
 
+.grid-2,
 .grid-3 {
   display: grid;
   gap: 1.5rem;
+}
+
+.grid-2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.grid-3 {
   grid-template-columns: repeat(3, 1fr);
 }
 
 @media (max-width: 820px) {
+  .grid-2,
   .grid-3 {
     grid-template-columns: 1fr;
   }

--- a/website/docs/getting-started.html
+++ b/website/docs/getting-started.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Getting started — IronKernel</title>
+    <meta name="description" content="Install IronKernel, run your first program, and create an IKC package." />
+    <link rel="stylesheet" href="../assets/site.css" />
+  </head>
+  <body>
+    <header class="nav">
+      <div class="wrap nav-inner">
+        <a class="brand" href="../index.html">IronKernel</a>
+        <ul class="nav-links">
+          <li><a href="getting-started.html" aria-current="page">Start</a></li>
+          <li><a href="intro.html">Intro</a></li>
+          <li><a href="guide.html">Guide</a></li>
+          <li><a href="operators.html">Operators</a></li>
+          <li><a href="https://github.com/ironkernel-lang/IronKernel">GitHub</a></li>
+        </ul>
+      </div>
+    </header>
+
+    <div class="wrap docs-shell">
+      <aside class="docs-side">
+        <h2>Docs</h2>
+        <ol>
+          <li><a href="getting-started.html" aria-current="page">Getting started</a></li>
+          <li><a href="intro.html">Introduction</a></li>
+          <li><a href="guide.html">Language guide</a></li>
+          <li><a href="operators.html">Operators</a></li>
+        </ol>
+        <h2 style="margin-top: 1.5rem">On this page</h2>
+        <ol>
+          <li><a href="#install">Install</a></li>
+          <li><a href="#first-run">First run</a></li>
+          <li><a href="#scripts">Scripts &amp; args</a></li>
+          <li><a href="#packages">IKC packages</a></li>
+          <li><a href="#errors">Read errors</a></li>
+          <li><a href="#next">Next steps</a></li>
+        </ol>
+      </aside>
+
+      <article class="docs-main">
+        <h1>Get running in five commands</h1>
+        <p class="lede">
+          Build IronKernel, run a real program, then package it. Scripts, packages, and the REPL
+          all start with the standard library loaded.
+        </p>
+
+        <h2 id="install">1. Install</h2>
+        <p>Choose the .NET SDK for development or a self-contained release for immediate use.</p>
+        <div class="grid-2">
+          <div class="example">
+            <p class="example-caption">Build from source · .NET 10 SDK</p>
+            <pre><code>git clone https://github.com/ironkernel-lang/IronKernel
+cd IronKernel
+dotnet build
+dotnet test</code></pre>
+          </div>
+          <div class="example">
+            <p class="example-caption">Release archive</p>
+            <pre><code>tar -xzf ironkernel-linux-x64.tar.gz
+cd ironkernel-linux-x64
+./IronKernel --version</code></pre>
+          </div>
+        </div>
+        <p>
+          Release archives include <code>kernel.scm</code> and <code>promises.scm</code>.
+          Keep them beside the executable.
+        </p>
+
+        <h2 id="first-run">2. Start the REPL</h2>
+        <div class="example">
+          <pre><code>dotnet run --project IronKernel
+# Release binary:
+./IronKernel</code></pre>
+        </div>
+        <p>
+          Enter <code>(+ 20 22)</code> and type <code>quit</code> to leave. The interactive line
+          editor needs a real terminal; use script mode in automation.
+        </p>
+
+        <h2 id="scripts">3. Run a script</h2>
+        <div class="example">
+          <pre><code>dotnet run --project IronKernel -- Examples/hello.scm
+dotnet run --project IronKernel -- run Examples/hello.scm one two</code></pre>
+          <div class="example-out">Hello,world!</div>
+        </div>
+        <p>
+          Arguments are available as the Kernel list <code>args</code>. Script paths are resolved
+          from your current directory; standard-library files are found there or beside the runtime.
+        </p>
+
+        <h2 id="packages">4. Validate and package</h2>
+        <div class="example">
+          <pre><code>dotnet run --project IronKernel -- compile Examples/hello.scm -o hello.ikc
+dotnet run --project IronKernel -- run hello.ikc</code></pre>
+        </div>
+        <p>
+          An <code>.ikc</code> file is an IronKernel source package, not a CLR assembly.
+          Packaging validates and compiles the source without executing it; execution happens only
+          when you run the package.
+        </p>
+
+        <h2 id="errors">5. Read errors at the source</h2>
+        <p>Diagnostics identify the file and range, then underline the failing form.</p>
+        <div class="example">
+          <pre><code>demo.scm:2:1: Getting an unbound variable: 'missing'
+(missing 42)
+^^^^^^^^^^^^</code></pre>
+        </div>
+        <p>
+          Startup, script, compile, and package failures go to stderr and return a non-zero exit code,
+          making the CLI suitable for build tools and editor integrations.
+        </p>
+
+        <h2 id="next">Where next?</h2>
+        <div class="cta-row">
+          <a class="btn btn-primary" href="intro.html">Understand Kernel</a>
+          <a class="btn btn-ghost" href="guide.html">Follow the language guide</a>
+          <a class="btn btn-ghost" href="https://github.com/ironkernel-lang/IronKernel/tree/master/Examples">Browse examples</a>
+        </div>
+      </article>
+    </div>
+
+    <footer class="footer">
+      <div class="wrap">
+        <span>IronKernel docs</span>
+        <span><a href="../index.html">Home</a> · <a href="operators.html">Operators</a></span>
+      </div>
+    </footer>
+    <script src="../assets/site.js"></script>
+  </body>
+</html>

--- a/website/docs/guide.html
+++ b/website/docs/guide.html
@@ -5,21 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Language guide — IronKernel</title>
     <meta name="description" content="A progressive tour of IronKernel with examples at every step." />
-    <link rel="icon" href="../assets/ironkernel-mark.png" type="image/png" />
     <link rel="stylesheet" href="../assets/site.css" />
   </head>
   <body>
     <header class="nav">
       <div class="wrap nav-inner">
         <a class="brand" href="../index.html">
-          <img src="../assets/ironkernel-mark.png" alt="" width="32" height="32" />
           IronKernel
         </a>
         <ul class="nav-links">
+          <li><a href="getting-started.html">Start</a></li>
           <li><a href="intro.html">Intro</a></li>
           <li><a href="guide.html" aria-current="page">Guide</a></li>
           <li><a href="operators.html">Operators</a></li>
-          <li><a href="https://github.com/ademar/IronKernel">GitHub</a></li>
+          <li><a href="https://github.com/ironkernel-lang/IronKernel">GitHub</a></li>
         </ul>
       </div>
     </header>
@@ -28,6 +27,7 @@
       <aside class="docs-side">
         <h2>Docs</h2>
         <ol>
+          <li><a href="getting-started.html">Getting started</a></li>
           <li><a href="intro.html">Introduction</a></li>
           <li><a href="guide.html" aria-current="page">Language guide</a></li>
           <li><a href="operators.html">Operators</a></li>
@@ -50,8 +50,8 @@
       <article class="docs-main">
         <h1>Language guide</h1>
         <p class="lede">
-          A tour with a small example at every step. Load <code>kernel.scm</code> in the REPL first
-          (<code>(load "kernel.scm")</code>) for library forms like <code>lambda</code> and <code>let</code>.
+          A tour with a small example at every step. The REPL, scripts, and packages load
+          library forms such as <code>lambda</code> and <code>let</code> automatically.
         </p>
 
         <h2 id="values">1. Values &amp; quotes</h2>
@@ -222,7 +222,7 @@ x
 
         <p>
           See the full sample in
-          <a href="https://github.com/ademar/IronKernel/blob/master/Examples/vau-dotnet.scm"><code>Examples/vau-dotnet.scm</code></a>,
+          <a href="https://github.com/ironkernel-lang/IronKernel/blob/master/Examples/vau-dotnet.scm"><code>Examples/vau-dotnet.scm</code></a>,
           then keep <a href="operators.html">operators.html</a> open as a reference.
         </p>
       </article>

--- a/website/docs/intro.html
+++ b/website/docs/intro.html
@@ -5,21 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Introduction — IronKernel</title>
     <meta name="description" content="What is Kernel, and how IronKernel brings it to the .NET CLR." />
-    <link rel="icon" href="../assets/ironkernel-mark.png" type="image/png" />
     <link rel="stylesheet" href="../assets/site.css" />
   </head>
   <body>
     <header class="nav">
       <div class="wrap nav-inner">
         <a class="brand" href="../index.html">
-          <img src="../assets/ironkernel-mark.png" alt="" width="32" height="32" />
           IronKernel
         </a>
         <ul class="nav-links">
+          <li><a href="getting-started.html">Start</a></li>
           <li><a href="intro.html" aria-current="page">Intro</a></li>
           <li><a href="guide.html">Guide</a></li>
           <li><a href="operators.html">Operators</a></li>
-          <li><a href="https://github.com/ademar/IronKernel">GitHub</a></li>
+          <li><a href="https://github.com/ironkernel-lang/IronKernel">GitHub</a></li>
         </ul>
       </div>
     </header>
@@ -28,6 +27,7 @@
       <aside class="docs-side">
         <h2>Docs</h2>
         <ol>
+          <li><a href="getting-started.html">Getting started</a></li>
           <li><a href="intro.html" aria-current="page">Introduction</a></li>
           <li><a href="guide.html">Language guide</a></li>
           <li><a href="operators.html">Operators</a></li>
@@ -126,7 +126,8 @@
 
         <h2 id="next">Next steps</h2>
         <p>
-          Walk through the <a href="guide.html">language guide</a> for progressive examples, or jump to the
+          <a href="getting-started.html">Run your first program</a>, walk through the
+          <a href="guide.html">language guide</a> for progressive examples, or jump to the
           <a href="operators.html">operator reference</a> when you need a precise signature.
         </p>
       </article>

--- a/website/docs/operators.html
+++ b/website/docs/operators.html
@@ -5,21 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Operators — IronKernel</title>
     <meta name="description" content="Reference for IronKernel primitive and standard-library operators." />
-    <link rel="icon" href="../assets/ironkernel-mark.png" type="image/png" />
     <link rel="stylesheet" href="../assets/site.css" />
   </head>
   <body>
     <header class="nav">
       <div class="wrap nav-inner">
         <a class="brand" href="../index.html">
-          <img src="../assets/ironkernel-mark.png" alt="" width="32" height="32" />
           IronKernel
         </a>
         <ul class="nav-links">
+          <li><a href="getting-started.html">Start</a></li>
           <li><a href="intro.html">Intro</a></li>
           <li><a href="guide.html">Guide</a></li>
           <li><a href="operators.html" aria-current="page">Operators</a></li>
-          <li><a href="https://github.com/ademar/IronKernel">GitHub</a></li>
+          <li><a href="https://github.com/ironkernel-lang/IronKernel">GitHub</a></li>
         </ul>
       </div>
     </header>
@@ -28,6 +27,7 @@
       <aside class="docs-side">
         <h2>Docs</h2>
         <ol>
+          <li><a href="getting-started.html">Getting started</a></li>
           <li><a href="intro.html">Introduction</a></li>
           <li><a href="guide.html">Language guide</a></li>
           <li><a href="operators.html" aria-current="page">Operators</a></li>
@@ -52,7 +52,7 @@
         <h1>Operator reference</h1>
         <p class="lede">
           Primitive operatives and applicatives ship with the runtime; the standard library
-          (<code>kernel.scm</code> / <code>promises.scm</code>) is loaded by the REPL.
+          (<code>kernel.scm</code> / <code>promises.scm</code>) is loaded by the REPL, scripts, and packages.
           Kind badges: <span class="op-kind">operative</span> unevaluated operands ·
           <span class="op-kind">applicative</span> args evaluated first ·
           <span class="op-kind">library</span> defined in Scheme.
@@ -97,7 +97,7 @@
           <p class="op-sig">(define lhs rhs)</p>
           <p>Evaluates <code>rhs</code>, then pattern-binds <code>lhs</code> in the current environment.</p>
           <div class="example">
-            <pre><code>(define (pts x y) (list x y))  ; via defn sugar in stdlib
+            <pre><code>(defn (pts x y) (list x y))
 (define answer 42)</code></pre>
           </div>
         </section>
@@ -424,7 +424,7 @@
 
         <p style="margin-top: 3rem">
           Prefer learning by doing? Return to the <a href="guide.html">language guide</a>
-          or browse <a href="https://github.com/ademar/IronKernel/tree/master/Examples">Examples/</a> in the repo.
+          or browse <a href="https://github.com/ironkernel-lang/IronKernel/tree/master/Examples">Examples/</a> in the repo.
         </p>
       </article>
     </div>

--- a/website/index.html
+++ b/website/index.html
@@ -8,16 +8,16 @@
       name="description"
       content="IronKernel is a Kernel dialect for .NET: first-class operatives, environments, and continuations — I run on .NET."
     />
-    <link rel="icon" href="assets/ironkernel-mark.png" type="image/png" />
     <link rel="stylesheet" href="assets/site.css" />
   </head>
   <body>
     <header class="nav">
       <div class="wrap nav-inner">
         <a class="brand" href="index.html" aria-label="IronKernel home">
-          <img src="assets/ironkernel-mark.png" alt="" width="32" height="32" />
+          IronKernel
         </a>
         <ul class="nav-links">
+          <li><a href="docs/getting-started.html">Start</a></li>
           <li><a href="docs/intro.html">Intro</a></li>
           <li><a href="docs/guide.html">Guide</a></li>
           <li><a href="docs/operators.html">Operators</a></li>
@@ -34,8 +34,8 @@
           and <em>I run on .NET</em>.
         </p>
         <div class="cta-row">
-          <a class="btn btn-primary" href="docs/intro.html">Read the intro</a>
-          <a class="btn btn-ghost" href="docs/guide.html">Start the guide</a>
+          <a class="btn btn-primary" href="docs/getting-started.html">Get started</a>
+          <a class="btn btn-ghost" href="docs/intro.html">Read the intro</a>
           <a class="btn btn-ghost" href="https://github.com/ironkernel-lang/IronKernel/releases">Get the binary</a>
         </div>
       </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add nested source spans through a parallel located syntax tree while preserving `LispVal` datum semantics
- attach filenames, line/column positions, source lines, and caret ranges to parse and top-level runtime errors
- thread named source through scripts, packages, compiler validation, and language-level loads
- add a responsive website getting-started path, example catalog, corrected navigation, and current CLI documentation

## Validation
- 66 Debug and Release tests pass
- runtime errors display source ranges and still return exit code 1
- all local documentation routes and assets return successfully
- desktop and mobile onboarding flows were manually verified

[ironkernel_onboarding_feature_demo.mp4](https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fironkernel_onboarding_feature_demo.mp4)

[IronKernel getting started page](https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboarding_getting_started.webp)

## Design
The existing unspanned parser API remains available. Located syntax is lowered to ordinary Kernel values at evaluation boundaries so source metadata does not affect equality or homoiconic program data.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786905050&installation_id=147070874&pr_number=6&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F6&signature=79b274f69f9e60f07f245dccdbb5b1a3975f20e71eb237de5d9f4b997127e96c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->